### PR TITLE
Configuration base_template

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,8 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('mail_reply_to')
                     ->defaultValue('')
                 ->end()
+                ->scalarNode('base_template')
+                    ->defaultValue('@Mail/base.html.twig')
             ->end()
         ;
 

--- a/DependencyInjection/MailExtension.php
+++ b/DependencyInjection/MailExtension.php
@@ -37,8 +37,13 @@ class MailExtension extends Extension
         $mailAddressFrom = $config['mail_address_from'];
         $mailAliasFrom = $config['mail_alias_from'];
         $mailReplyTo = $config['mail_reply_to'];
+        $baseTemplate = $config['base_template'];
 
-        $container->getDefinition(MailTemplate::class)->replaceArgument(0, new Reference($templateProvider));
+        $container->getDefinition(MailTemplate::class)
+            ->replaceArgument(0, new Reference($templateProvider))
+            ->setMethodCalls([
+                ['setBaseTemplate', [$baseTemplate]],
+            ]);
 
         $container->getDefinition(SwiftMailSender::class)->replaceArgument(1, new Reference($mailProvider));
 
@@ -47,7 +52,7 @@ class MailExtension extends Extension
         $container->getDefinition(MailBuilder::class)->setMethodCalls([
             ['setMailAddressFrom', [$mailAddressFrom]],
             ['setMailAliasFrom', [$mailAliasFrom]],
-            ['setMailReplyTo', [$mailReplyTo]]
+            ['setMailReplyTo', [$mailReplyTo]],
         ]);
 
         $container->getDefinition(Sender::class)

--- a/Entity/Mail.php
+++ b/Entity/Mail.php
@@ -259,7 +259,7 @@ class Mail implements MailInterface
      */
     public function addRecipient(string $recipient)
     {
-        $recipients =  empty($this->recipient) ? [] : explode('|', $this->recipient);
+        $recipients = empty($this->recipient) ? [] : explode('|', $this->recipient);
         $recipients[] = $recipient;
 
         $this->recipient = implode('|', $recipients);
@@ -270,7 +270,7 @@ class Mail implements MailInterface
      */
     public function getRecipientCopy()
     {
-        return empty($this->recipientCopy) ? [] :explode('|', $this->recipientCopy);
+        return empty($this->recipientCopy) ? [] : explode('|', $this->recipientCopy);
     }
 
     /**

--- a/Exception/MailSenderException.php
+++ b/Exception/MailSenderException.php
@@ -9,6 +9,7 @@ class MailSenderException extends \Exception
 {
     /**
      * MailTemplateNotFoundException constructor.
+     *
      * @param string $message
      */
     public function __construct($message = 'Mail not sent')

--- a/Exception/MailerSenderEmptyException.php
+++ b/Exception/MailerSenderEmptyException.php
@@ -1,25 +1,26 @@
 <?php
 
-
 namespace Extellient\MailBundle\Exception;
 
 use Extellient\MailBundle\Entity\MailInterface;
 
 /**
- * Class MailerSenderEmptyException
+ * Class MailerSenderEmptyException.
  */
 class MailerSenderEmptyException extends MailSenderException
 {
     /**
-     * Mail Identifier
+     * Mail Identifier.
+     *
      * @var MailInterface
      */
     protected $mail;
 
     /**
      * MailerSenderEmptyException constructor.
+     *
      * @param MailInterface|null $mail
-     * @param string $message
+     * @param string             $message
      */
     public function __construct(MailInterface $mail = null, $message = 'The Mailer has an empty sender_email')
     {

--- a/Repository/MailRepository.php
+++ b/Repository/MailRepository.php
@@ -30,7 +30,7 @@ class MailRepository extends ServiceEntityRepository
     {
         return parent::findBy([
             'sentDate' => $sendDate,
-            'sentError' => false
+            'sentError' => false,
         ]);
     }
 }

--- a/Sender/SwiftMailSender.php
+++ b/Sender/SwiftMailSender.php
@@ -51,7 +51,6 @@ class SwiftMailSender implements MailSenderInterface
             ->setCc($mail->getRecipientCopy())
             ->setBcc($mail->getRecipientHiddenCopy());
 
-
         if (empty($mail->getSenderEmail())) {
             throw new MailerSenderEmptyException($mail);
         }

--- a/Services/MailBuilder.php
+++ b/Services/MailBuilder.php
@@ -1,12 +1,11 @@
 <?php
 
-
 namespace Extellient\MailBundle\Services;
 
 use Extellient\MailBundle\Entity\Mail;
 
 /**
- * Class MailBuilder
+ * Class MailBuilder.
  */
 class MailBuilder
 {
@@ -25,7 +24,7 @@ class MailBuilder
 
     /**
      * Create an entity Mail with the basic requierement for a mail.
-     * Which will return the Mail entity
+     * Which will return the Mail entity.
      *
      * @param $subject
      * @param $body

--- a/Services/MailTemplating.php
+++ b/Services/MailTemplating.php
@@ -32,7 +32,7 @@ class MailTemplating implements MailTemplatingInterface
 
     /**
      * Create an entity Mail with the basic requierement for a mail from a MailTemplate name
-     * Which will return the Mail entity
+     * Which will return the Mail entity.
      *
      * @param string       $templateCode
      * @param array|string $recipients

--- a/Services/Mailer.php
+++ b/Services/Mailer.php
@@ -24,7 +24,7 @@ class Mailer
      * MailService constructor.
      *
      * @param MailProviderInterface $mailProvider
-     * @param MailBuilder $mailBuilder
+     * @param MailBuilder           $mailBuilder
      */
     public function __construct(MailProviderInterface $mailProvider, MailBuilder $mailBuilder)
     {

--- a/Template/MailTemplate.php
+++ b/Template/MailTemplate.php
@@ -24,6 +24,10 @@ class MailTemplate
      * @var LoggerInterface
      */
     private $logger;
+    /**
+     * @var string|null
+     */
+    private $baseTemplate;
 
     /**
      * Template constructor.
@@ -55,6 +59,14 @@ class MailTemplate
     {
         $mailTemplate = $this->mailProvider->findOneTemplateByCode($code);
 
-        return new MailTemplateRenderer($this->twig, $mailTemplate, $this->logger);
+        return new MailTemplateRenderer($this->twig, $mailTemplate, $this->logger, $this->baseTemplate);
+    }
+
+    /**
+     * @param string|null $baseTemplate
+     */
+    public function setBaseTemplate(string $baseTemplate = null)
+    {
+        $this->baseTemplate = $baseTemplate;
     }
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -36,6 +36,7 @@ class ConfigurationTest extends TestCase
     {
         return [
             [
+                //Config Test Mails Configuration
                 [
                     'extellient_mail' => [
                         'mail_address_from' => 'test@test.com',
@@ -43,6 +44,7 @@ class ConfigurationTest extends TestCase
                         'mail_reply_to' => 'test@test.com',
                     ],
                 ],
+                //Excepted Config (processConfiguration)
                 [
                     'mail_service_provider' => DoctrineMailProvider::class,
                     'mail_template_service_provider' => DoctrineMailTemplateProvider::class,
@@ -50,8 +52,47 @@ class ConfigurationTest extends TestCase
                     'mail_address_from' => 'test@test.com',
                     'mail_alias_from' => 'test@test.com',
                     'mail_reply_to' => 'test@test.com',
+                    'base_template' => '@Mail/base.html.twig',
                 ],
             ],
+            [
+                //Config Test Base Template Configuration
+                [
+                    'extellient_mail' => [
+                        'base_template' => '@Mail/base.html.twig',
+                    ],
+                ],
+                //Excepted Config (processConfiguration)
+                [
+                    'mail_service_provider' => DoctrineMailProvider::class,
+                    'mail_template_service_provider' => DoctrineMailTemplateProvider::class,
+                    'mail_sender_service_provider' => SwiftMailSender::class,
+                    'mail_address_from' => '',
+                    'mail_alias_from' => '',
+                    'mail_reply_to' => '',
+                    'base_template' => '@Mail/base.html.twig',
+                ]
+            ],
+            [
+                //Config test Mail Providers
+                [
+                    'extellient_mail' => [
+                        'mail_service_provider' => 'App\\Provider\\MailServiceClass',
+                        'mail_template_service_provider' => 'App\\Provider\\TemplateServiceClass',
+                        'mail_sender_service_provider' => 'App\\Provider\\SenderServiceClass',
+                    ],
+                ],
+                //Excepted Config (processConfiguration)
+                [
+                    'mail_service_provider' => 'App\\Provider\\MailServiceClass',
+                    'mail_template_service_provider' => 'App\\Provider\\TemplateServiceClass',
+                    'mail_sender_service_provider' => 'App\\Provider\\SenderServiceClass',
+                    'mail_address_from' => '',
+                    'mail_alias_from' => '',
+                    'mail_reply_to' => '',
+                    'base_template' => '@Mail/base.html.twig',
+                ]
+            ]
         ];
     }
 }

--- a/Tests/DependencyInjection/MailExtensionTest.php
+++ b/Tests/DependencyInjection/MailExtensionTest.php
@@ -30,11 +30,7 @@ class MailExtensionTest extends TestCase
     {
         $container = $this->createContainer();
         $container->registerExtension(new MailExtension());
-        $container->loadFromExtension('extellient_mail', [
-            'mail_address_from' => 'test@test.com',
-            'mail_alias_from' => 'test@test.com',
-            'mail_reply_to' => 'test@test.com',
-        ]);
+        $container->loadFromExtension('extellient_mail');
         $this->compileContainer($container);
 
         $this->assertEquals(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

I am targeting this branch, because we want to be able to use or not a base template.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added base_template configuration to change or don't use at all a base_template

### Changed
- Update code style with php-cs-fixer with --rules=@Symfony,-@PSR1,-blank_line_before_statement
- Update test Configuration and Extension
```
<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
## Subject

You can change the default base_template : `@Mail\base.html.twig`, with your own custom template by adding it to the extellient_mail configuration or don't use a base_template at all.

<!-- Describe your Pull Request content here -->
